### PR TITLE
Update kelcom.net

### DIFF
--- a/ispdb/kelcom.net.xml
+++ b/ispdb/kelcom.net.xml
@@ -1,21 +1,21 @@
-<clientConfig  version="1.1">
-    <emailProvider id="kelcom.net">
-        <domain>kelcom.net</domain>
-        <displayName>KELCOM Internet</displayName>
-        <displayShortName>KELCOM</displayShortName>
-        <incomingServer type="pop3">
-            <hostname>pop1.kelcom.net</hostname>
-            <port>110</port>
-            <socketType>plain</socketType>
-            <username>%EMAILADDRESS%</username>
-            <authentication>password-cleartext</authentication>
-        </incomingServer>
-        <outgoingServer type="smtp">
-            <hostname>smtp.kelcom.net</hostname>
-            <port>25</port>
-            <socketType>plain</socketType>
-            <username>%EMAILADDRESS%</username>
-            <authentication>password-cleartext</authentication>
-        </outgoingServer>
-    </emailProvider>
+<clientConfig version="1.1">
+  <emailProvider id="kelcom.net">
+    <domain>kelcom.net</domain>
+    <displayName>KELCOM Internet</displayName>
+    <displayShortName>KELCOM</displayShortName>
+    <incomingServer type="pop3">
+      <hostname>pop1.kelcom.net</hostname>
+      <port>110</port>
+      <socketType>plain</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <outgoingServer type="smtp">
+      <hostname>smtp.kelcom.net</hostname>
+      <port>25</port>
+      <socketType>plain</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </outgoingServer>
+  </emailProvider>
 </clientConfig>

--- a/ispdb/kelcom.net.xml
+++ b/ispdb/kelcom.net.xml
@@ -3,19 +3,27 @@
     <domain>kelcom.net</domain>
     <displayName>KELCOM Internet</displayName>
     <displayShortName>KELCOM</displayShortName>
+    <incomingServer type="imap">
+      <hostname>pop.kelcom.net</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
     <incomingServer type="pop3">
-      <hostname>pop1.kelcom.net</hostname>
-      <port>110</port>
-      <socketType>plain</socketType>
+      <hostname>pop.kelcom.net</hostname>
+      <port>995</port>
+      <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </incomingServer>
     <outgoingServer type="smtp">
       <hostname>smtp.kelcom.net</hostname>
-      <port>25</port>
-      <socketType>plain</socketType>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
+    <documentation url="https://portal.kelcom.net/support/faq/6/"/>
   </emailProvider>
 </clientConfig>


### PR DESCRIPTION
Update kelcom.net settings:
- add IMAP config
- use TLS
- add documentation URL

Note: `imap.kelcom.net` exists and ultimately points to the same address as `pop.kelcom.net`. However, the name `imap.kelcom.net` is not included as subject alternative name in the TLS certificate.