### PR TITLE
Move `documentation` elements to their specified place

### DIFF
--- a/ispdb/bigpond.com.xml
+++ b/ispdb/bigpond.com.xml
@@ -28,8 +28,8 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
+    <documentation url="https://www.telstra.com.au/support/category/email/telstra-mail/recommended-email-settings-for-telstra-mail">
+      <descr lang="en">Recommended email settings</descr>
+    </documentation>
   </emailProvider>
-  <documentation url="https://www.telstra.com.au/support/category/email/telstra-mail/recommended-email-settings-for-telstra-mail">
-    <descr lang="en">Recommended email settings</descr>
-  </documentation>
 </clientConfig>

--- a/ispdb/mail.telenor.dk.xml
+++ b/ispdb/mail.telenor.dk.xml
@@ -112,10 +112,10 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
+    <documentation url="http://www.telenor.dk/privat/kundeservice/kundeservice/bredbaand/opsaetning/email-og-hjemmeside/tabs/opsaetning/outlook-express-6.0.aspx"/>
+    <documentation url="http://www.telenor.dk/privat/kundeservice/kundeservice/bredbaand/opsaetning/email-og-hjemmeside/tabs/opsaetning/windows-live-mail.aspx"/>
+    <documentation url="http://mailselvbetjening.telenor.dk/">
+      <descr lang="en">Domain list source (requires login)</descr>
+    </documentation>
   </emailProvider>
-  <documentation url="http://www.telenor.dk/privat/kundeservice/kundeservice/bredbaand/opsaetning/email-og-hjemmeside/tabs/opsaetning/outlook-express-6.0.aspx"/>
-  <documentation url="http://www.telenor.dk/privat/kundeservice/kundeservice/bredbaand/opsaetning/email-og-hjemmeside/tabs/opsaetning/windows-live-mail.aspx"/>
-  <documentation url="http://mailselvbetjening.telenor.dk/">
-    <descr lang="en">Domain list source (requires login)</descr>
-  </documentation>
 </clientConfig>

--- a/ispdb/rambler.ru.xml
+++ b/ispdb/rambler.ru.xml
@@ -25,11 +25,11 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
+    <documentation url="https://help.rambler.ru/mail/mail-pochtovye-klienty/1277/">
+      <descr lang="ru">Как настроить Mozilla Thunderbird?</descr>
+    </documentation>
+    <documentation url="https://help.rambler.ru/mail/mail-pochtovye-klienty/1275/">
+      <descr lang="ru">Общие настройки для почтовых клиентов</descr>
+    </documentation>
   </emailProvider>
-  <documentation url="https://help.rambler.ru/mail/mail-pochtovye-klienty/1277/">
-    <descr lang="ru">Как настроить Mozilla Thunderbird?</descr>
-  </documentation>
-  <documentation url="https://help.rambler.ru/mail/mail-pochtovye-klienty/1275/">
-    <descr lang="ru">Общие настройки для почтовых клиентов</descr>
-  </documentation>
 </clientConfig>

--- a/ispdb/ziggo.nl.xml
+++ b/ispdb/ziggo.nl.xml
@@ -38,9 +38,9 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
+    <documentation url="https://www.ziggo.nl/klantenservice/e-mail/?src=autoconfig">
+      <descr lang="en">E-mail Settings</descr>
+      <descr lang="nl">Instellingen voor e-mail</descr>
+    </documentation>
   </emailProvider>
-  <documentation url="https://www.ziggo.nl/klantenservice/e-mail/?src=autoconfig">
-    <descr lang="en">E-mail Settings</descr>
-    <descr lang="nl">Instellingen voor e-mail</descr>
-  </documentation>
 </clientConfig>

--- a/ispdb/zoho.com.xml
+++ b/ispdb/zoho.com.xml
@@ -37,26 +37,26 @@
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
+    <documentation url="https://www.zoho.com/mail/help/imap-access.html">
+      <descr lang="en">Zoho Mail - Access via IMAP</descr>
+    </documentation>
+    <documentation url="https://www.zoho.com/mail/help/imap-access.html">
+      <descr lang="en">Zoho Mail - POP configuration details</descr>
+    </documentation>
+    <documentation url="https://www.zoho.com/mail/help/zoho-smtp.html">
+      <descr lang="en">Zoho Mail - SMTP Server Configuration</descr>
+    </documentation>
+    <documentation url="https://www.zoho.com/mail/help/thunderbird-imap-access.html">
+      <descr lang="en">Configure Zoho Mail as IMAP Account in Thunderbird</descr>
+    </documentation>
+    <documentation url="https://www.zoho.com/mail/help/thunderbird-pop-access.html">
+      <descr lang="en">Configure your Zoho Account as POP in Thunderbird</descr>
+    </documentation>
+    <documentation url="https://www.zoho.com/mail/help/pop-access.html#EnablePOPAccess">
+      <descr lang="en">Enable POP Access</descr>
+    </documentation>
+    <documentation url="https://www.zoho.com/mail/help/imap-access.html#EnableIMAP">
+      <descr lang="en">Enable IMAP Access</descr>
+    </documentation>
   </emailProvider>
-  <documentation url="https://www.zoho.com/mail/help/imap-access.html">
-    <descr lang="en">Zoho Mail - Access via IMAP</descr>
-  </documentation>
-  <documentation url="https://www.zoho.com/mail/help/imap-access.html">
-    <descr lang="en">Zoho Mail - POP configuration details</descr>
-  </documentation>
-  <documentation url="https://www.zoho.com/mail/help/zoho-smtp.html">
-    <descr lang="en">Zoho Mail - SMTP Server Configuration</descr>
-  </documentation>
-  <documentation url="https://www.zoho.com/mail/help/thunderbird-imap-access.html">
-    <descr lang="en">Configure Zoho Mail as IMAP Account in Thunderbird</descr>
-  </documentation>
-  <documentation url="https://www.zoho.com/mail/help/thunderbird-pop-access.html">
-    <descr lang="en">Configure your Zoho Account as POP in Thunderbird</descr>
-  </documentation>
-  <documentation url="https://www.zoho.com/mail/help/pop-access.html#EnablePOPAccess">
-    <descr lang="en">Enable POP Access</descr>
-  </documentation>
-  <documentation url="https://www.zoho.com/mail/help/imap-access.html#EnableIMAP">
-    <descr lang="en">Enable IMAP Access</descr>
-  </documentation>
 </clientConfig>


### PR DESCRIPTION
According to the format specification `documentation` elements go inside the `emailProvider` element.