### PR TITLE
Move `enable` elements to their specified place

### DIFF
--- a/ispdb/inbox.lv.xml
+++ b/ispdb/inbox.lv.xml
@@ -37,13 +37,6 @@
        <descr lang="lt">Pašto programų nustatymai (IMAP, POP3, SMTP)</descr>
        <descr lang="ru">Настройки для почтовых программ (IMAP, POP3,SMTP и др.)</descr>
     </documentation>
-    <enable visiturl="https://help.inbox.lv/?keyword=email_clients_access">
-      <instruction>Enable external POP3/IMAP and SMTP access in your account settings</instruction>
-      <instruction lang="lv">Ieslēgt POP3/IMAP pieeju savam kontam</instruction>
-      <instruction lang="ru">Доступ POP3/IMAP, пароль для почтовой программы</instruction>
-      <instruction lang="lt">POP3/IMAP prieiga, pašto programų slaptažodis</instruction>
-      <instruction lang="et">POP3/IMAP juurdepääs, e-posti programmi parool</instruction>
-    </enable>
   </emailProvider>
   <webMail>
     <loginPage url="https://login.%EMAILDOMAIN%" />
@@ -54,4 +47,11 @@
       <loginButton id="implogin__btn_sign-in"/>
     </loginPageInfo>
   </webMail>
+  <enable visiturl="https://help.inbox.lv/?keyword=email_clients_access">
+    <instruction>Enable external POP3/IMAP and SMTP access in your account settings</instruction>
+    <instruction lang="lv">Ieslēgt POP3/IMAP pieeju savam kontam</instruction>
+    <instruction lang="ru">Доступ POP3/IMAP, пароль для почтовой программы</instruction>
+    <instruction lang="lt">POP3/IMAP prieiga, pašto programų slaptažodis</instruction>
+    <instruction lang="et">POP3/IMAP juurdepääs, e-posti programmi parool</instruction>
+  </enable>
 </clientConfig>

--- a/ispdb/mail.ee.xml
+++ b/ispdb/mail.ee.xml
@@ -34,13 +34,6 @@
        <descr lang="lt">Pašto programų nustatymai (IMAP, POP3, SMTP)</descr>
        <descr lang="ru">Настройки для почтовых программ (IMAP, POP3,SMTP и др.)</descr>
     </documentation>
-    <enable visiturl="https://help.mail.ee/?keyword=email_clients_access">
-      <instruction>Enable external POP3/IMAP and SMTP access in your account settings</instruction>
-      <instruction lang="lv">Ieslēgt POP3/IMAP pieeju savam kontam</instruction>
-      <instruction lang="ru">Доступ POP3/IMAP, пароль для почтовой программы</instruction>
-      <instruction lang="lt">POP3/IMAP prieiga, pašto programų slaptažodis</instruction>
-      <instruction lang="et">POP3/IMAP juurdepääs, e-posti programmi parool</instruction>
-    </enable>
   </emailProvider>
   <webMail>
     <loginPage url="https://login.%EMAILDOMAIN%" />
@@ -51,4 +44,11 @@
       <loginButton id="implogin__btn_sign-in"/>
     </loginPageInfo>
   </webMail>
+  <enable visiturl="https://help.mail.ee/?keyword=email_clients_access">
+    <instruction>Enable external POP3/IMAP and SMTP access in your account settings</instruction>
+    <instruction lang="lv">Ieslēgt POP3/IMAP pieeju savam kontam</instruction>
+    <instruction lang="ru">Доступ POP3/IMAP, пароль для почтовой программы</instruction>
+    <instruction lang="lt">POP3/IMAP prieiga, pašto programų slaptažodis</instruction>
+    <instruction lang="et">POP3/IMAP juurdepääs, e-posti programmi parool</instruction>
+  </enable>
 </clientConfig>

--- a/ispdb/uol.com.br.xml
+++ b/ispdb/uol.com.br.xml
@@ -25,10 +25,6 @@
       <username>%EMAILLOCALPART%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
-    <enable visiturl="http://bmail.uol.com.br/configuration/imap_access_config">
-      <instruction lang="pt-BR">Para usar o protocolo IMAP, você deve antes acessar as suas Configurações do webmail UOL, clicar na opção "Ativar IMAP" e então salvar as modificações.</instruction>
-      <instruction lang="en-US">To use IMAP, you must log in to webmail, go to "Settings", click "Activate IMAP"</instruction>
-    </enable>
     <documentation url="https://sac.uol.com.br/info/primeiros_passos/config_mozillathunderbird.jhtm">
       <descr lang="pt-BR">Configuração do Mozilla Thunderbird passo-a-passo</descr>
     </documentation>
@@ -39,4 +35,8 @@
       <descr lang="pt-BR">O que é IMAP e como ativá-lo na sua conta UOL</descr>
     </documentation>
   </emailProvider>
+  <enable visiturl="http://bmail.uol.com.br/configuration/imap_access_config">
+    <instruction lang="pt-BR">Para usar o protocolo IMAP, você deve antes acessar as suas Configurações do webmail UOL, clicar na opção "Ativar IMAP" e então salvar as modificações.</instruction>
+    <instruction lang="en-US">To use IMAP, you must log in to webmail, go to "Settings", click "Activate IMAP"</instruction>
+  </enable>
 </clientConfig>


### PR DESCRIPTION
according to spec "enable" should have clientConfig as parent instead of emailProvider.
This is the equivalent of #77