### PR TITLE
Remove gmx.com from gmx.net config

### DIFF
--- a/ispdb/gmx.net.xml
+++ b/ispdb/gmx.net.xml
@@ -9,7 +9,6 @@
     <domain>gmx.biz</domain>
     <domain>gmx.org</domain>
     <domain>gmx.info</domain>
-    <domain>gmx.com</domain>
     <domain>mein.gmx</domain>
     <domain>mail.gmx</domain>
     <domain>email.gmx</domain>


### PR DESCRIPTION
We have a separate config for gmx.com already.

This partially reverts a change from #91.