### PR TITLE
Update settings for earthlink.net

### DIFF
--- a/ispdb/earthlink.net.xml
+++ b/ispdb/earthlink.net.xml
@@ -9,15 +9,15 @@
     <displayShortName>EarthLink</displayShortName>
     <incomingServer type="imap">
       <hostname>imap.earthlink.net</hostname>
-      <port>143</port>
-      <socketType>plain</socketType>
+      <port>993</port>
+      <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
       <authentication>password-encrypted</authentication>
     </incomingServer>
     <incomingServer type="pop3">
       <hostname>pop.earthlink.net</hostname>
-      <port>110</port>
-      <socketType>plain</socketType>
+      <port>995</port>
+      <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
       <authentication>password-encrypted</authentication>
     </incomingServer>
@@ -26,10 +26,8 @@
       <port>587</port>
       <socketType>STARTTLS</socketType>
       <username>%EMAILADDRESS%</username>
-      <authentication>password-encrypted</authentication>
+      <authentication>password-cleartext</authentication>
     </outgoingServer>
-    <documentation url="http://support.earthlink.net/email/email-server-settings.php">
-      <descr>POP settings, domains</descr>
-    </documentation>
+    <documentation url="https://help.earthlink.net/portal/en/kb/articles/email-server-settings" />
   </emailProvider>
 </clientConfig>


### PR DESCRIPTION
Updating this because a K-9 Mail user [reported](https://forum.k9mail.app/t/earthlink-imap-not-working/8571) an Earthlink related issue that made me realize automatic setup didn't work for them. That's because K-9 Mail ignores entries not using any transport encryption.

I changed the authentication method for the outgoing server to `password-cleartext` because the server only announces support for `PLAIN` and `LOGIN`.

```text
> EHLO autoconfig.test
< 250-hello TLS
< 250-AUTH LOGIN PLAIN
< 250-8BITMIME
< 250-PIPELINING
< 250-HELP
< 250-CHUNKING
< 250-BINARYMIME
< 250 SIZE 52428800
``` 

Earthlink documentation: https://help.earthlink.net/portal/en/kb/articles/email-server-settings