### PR TITLE
Update settings for Strato

### DIFF
--- a/ispdb/strato.de.xml
+++ b/ispdb/strato.de.xml
@@ -12,32 +12,31 @@
       <hostname>imap.strato.de</hostname>
       <port>993</port>
       <socketType>SSL</socketType>
-      <authentication>password-encrypted</authentication>
+      <authentication>password-cleartext</authentication>
       <username>%EMAILADDRESS%</username>
     </incomingServer>
     <incomingServer type="pop3">
       <hostname>pop3.strato.de</hostname>
       <port>995</port>
       <socketType>SSL</socketType>
-      <authentication>password-encrypted</authentication>
+      <authentication>password-cleartext</authentication>
       <username>%EMAILADDRESS%</username>
     </incomingServer>
     <outgoingServer type="smtp">
       <hostname>smtp.strato.de</hostname>
       <port>465</port>
       <socketType>SSL</socketType>
-      <authentication>password-encrypted</authentication>
+      <authentication>password-cleartext</authentication>
       <username>%EMAILADDRESS%</username>
     </outgoingServer>
     <outgoingServer type="smtp">
       <hostname>smtp.strato.de</hostname>
       <port>587</port>
       <socketType>STARTTLS</socketType>
-      <authentication>password-encrypted</authentication>
+      <authentication>password-cleartext</authentication>
       <username>%EMAILADDRESS%</username>
     </outgoingServer>
-    <!--
-        Kundenservice: +49-1805-055055
-      -->
+
+    <documentation url="https://www.strato.de/faq/mail/externes-e-mail-programm-mit-strato-e-mail-adresse-nutzen/"/>
   </emailProvider>
 </clientConfig>


### PR DESCRIPTION
They removed support for CRAM-MD5 and don't support any other encrypted authentication methods.

See https://www.strato.de/faq/mail/externes-e-mail-programm-mit-strato-e-mail-adresse-nutzen/

(I am a customer and was notified of this via email)