### PR TITLE
Update settings for email.it

### DIFF
--- a/ispdb/email.it.xml
+++ b/ispdb/email.it.xml
@@ -5,29 +5,26 @@
     <displayName>email.it</displayName>
     <displayShortName>email.it</displayShortName>
     <incomingServer type="imap">
-      <hostname>imapmail.email.it</hostname>
+      <hostname>in.email.it</hostname>
       <port>993</port>
       <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
-      <authentication>password-encrypted</authentication>
+      <authentication>password-cleartext</authentication>
     </incomingServer>
     <incomingServer type="pop3">
-      <hostname>popmail.email.it</hostname>
+      <hostname>pop.email.it</hostname>
       <port>995</port>
       <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
-      <authentication>password-encrypted</authentication>
+      <authentication>password-cleartext</authentication>
     </incomingServer>
     <outgoingServer type="smtp">
-      <hostname>smtp.email.it</hostname>
-      <port>587</port>
-      <socketType>STARTTLS</socketType>
+      <hostname>out.email.it</hostname>
+      <port>465</port>
+      <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
-    <documentation url="http://www.email.it/ita/config/thunder.php"/>
-    <!--
-        You should set "IMAP server directory" to "INBOX"
-      -->
+    <documentation url="https://www.email.it/faq" />
   </emailProvider>
 </clientConfig>


### PR DESCRIPTION
It looks like the provider recently changed its business model and server settings. See <https://www.email.it/welcome> and <https://www.email.it/faq>.

I verified the server settings using:
```shell
openssl s_client -connect in.email.it:993 -crlf -verify_hostname in.email.it -ign_eof <<EOF
1 ID ("name" "autoconfig.test")
EOF
```

```shell
openssl s_client -connect pop.email.it:995 -crlf -verify_hostname pop.email.it -ign_eof <<EOF
CAPA
EOF
```

```shell
openssl s_client -connect out.email.it:465 -crlf -verify_hostname out.email.it -ign_eof <<EOF
EHLO autoconfig.test
EOF
```

Closes #116