### PR TITLE
Add NYU (Google) to ISPDB

### DIFF
--- a/ispdb/googlemail.com.xml
+++ b/ispdb/googlemail.com.xml
@@ -5,8 +5,8 @@
     <domain>googlemail.com</domain>
     <!-- MX, for Google Apps -->
     <domain>google.com</domain>
-    <!-- HACK. Only add ISPs with 100000+ users here -->
     <domain>jazztel.es</domain>
+    <domain>nyu.edu</domain>
 
     <displayName>Google Mail</displayName>
     <displayShortName>GMail</displayShortName>


### PR DESCRIPTION
Closes #111 

After discussing privately with an nyu.edu address holder, it looks like NYU's email is backed by Google for (at least) students. I'm still not clear on whether NYU runs separate configurations for different groups (e.g. students, teachers, etc), which is something I'm still looking into, but in the meantime this should help at least a majority of NYU address holders wishing to use Thunderbird.

I've also removed the comment about restricting which domains to add, because it's an old policy we don't really apply on other providers anymore.