### PR TITLE
Add entries for OX Cloud EU and US

### DIFF
--- a/ispdb/oxcloud-eu.xml
+++ b/ispdb/oxcloud-eu.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<clientConfig version="1.1">
+  <emailProvider id="OXCloud-EU">
+    <domain>cloudeu.xion.oxcs.net</domain>
+
+    <displayName>OX Cloud EU</displayName>
+    <displayShortName>OX Cloud EU</displayShortName>
+
+    <incomingServer type="imap">
+      <hostname>imap.eu.appsuite.cloud</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+    <incomingServer type="imap">
+      <hostname>imap.eu.appsuite.cloud</hostname>
+      <port>143</port>
+      <socketType>STARTTLS</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+    <incomingServer type="pop3">
+      <hostname>pop.eu.appsuite.cloud</hostname>
+      <port>995</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+    <outgoingServer type="smtp">
+      <hostname>smtp.eu.appsuite.cloud</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </outgoingServer>
+    <documentation url="https://confluence-public.open-xchange.com/display/OASC/OX+Cloud+%28OX+brand%29+endpoints"/>
+  </emailProvider>
+</clientConfig>

--- a/ispdb/oxcloud-us.xml
+++ b/ispdb/oxcloud-us.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<clientConfig version="1.1">
+  <emailProvider id="OXCloud-US">
+    <domain>cloudus.xion.oxcs.net</domain>
+
+    <displayName>OX Cloud US</displayName>
+    <displayShortName>OX Cloud US</displayShortName>
+
+    <incomingServer type="imap">
+      <hostname>imap.us.appsuite.cloud</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+    <incomingServer type="imap">
+      <hostname>imap.us.appsuite.cloud</hostname>
+      <port>143</port>
+      <socketType>STARTTLS</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+    <incomingServer type="pop3">
+      <hostname>pop.us.appsuite.cloud</hostname>
+      <port>995</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+    <outgoingServer type="smtp">
+      <hostname>smtp.us.appsuite.cloud</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </outgoingServer>
+    <documentation url="https://confluence-public.open-xchange.com/display/OASC/OX+Cloud+%28OX+brand%29+endpoints"/>
+  </emailProvider>
+</clientConfig>


### PR DESCRIPTION
Due to our global business selling EMail-Cloud-Services to several ISPs we need to have (for now) two different configurations  (US and EU).
We also rely on Thunderbird's intermediate MX lookup since we do not have any control over enduser's mail domains. Please let me know if there are any concerns. I'm open to discuss them.