### PR TITLE
Add config for MIT.EDU

### DIFF
--- a/ispdb/mit.edu.xml
+++ b/ispdb/mit.edu.xml
@@ -3,7 +3,7 @@
 <clientConfig version="1.1">
   <emailProvider id="mit.edu">
     <domain>mit.edu</domain>
-    <displayName>MIT IMAP Mail</displayName>
+    <displayName>MIT Mail</displayName>
     <displayShortName>MIT</displayShortName>
     <incomingServer type="imap">
       <hostname>outlook.office365.com</hostname>
@@ -14,13 +14,13 @@
     </incomingServer>
     <outgoingServer type="smtp">
       <hostname>outgoing.mit.edu</hostname>
-      <port>587</port>
-      <socketType>STARTTLS</socketType>
+      <port>465</port>
+      <socketType>SSL</socketType>
       <authentication>password-cleartext</authentication>
       <username>%EMAILLOCALPART%</username>
     </outgoingServer>
-    <documentation url="http://kb.mit.edu">
-      <descr lang="en">MIT Knowledgebase</descr>
+    <documentation url="https://kb.mit.edu/confluence/display/istcontrib/Microsoft+365+Email+and+Calendaring+-+Configure+via+IMAP+Settings">
+      <descr lang="en">Microsoft 365 Email and Calendaring - Configure via IMAP Settings</descr>
     </documentation>
   </emailProvider>
 </clientConfig>

--- a/ispdb/mit.edu.xml
+++ b/ispdb/mit.edu.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<clientConfig version="1.1">
+  <emailProvider id="mit.edu">
+    <domain>mit.edu</domain>
+    <displayName>MIT IMAP Mail</displayName>
+    <displayShortName>MIT</displayShortName>
+    <incomingServer type="imap">
+      <hostname>outlook.office365.com</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <authentication>OAuth2</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+    <outgoingServer type="smtp">
+      <hostname>outgoing.mit.edu</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILLOCALPART%</username>
+    </outgoingServer>
+    <documentation url="http://kb.mit.edu">
+      <descr lang="en">MIT Knowledgebase</descr>
+    </documentation>
+  </emailProvider>
+</clientConfig>


### PR DESCRIPTION
Hello all, I believe we (MIT) meet the criteria for inclusion in this database, though it wasn't clear to me if you preferred a submission on bugzilla or a PR here (it looks like both are happening, but please let me know if you'd like me to submit this differently.)

We have a slightly nonstandard config (for approximately good reasons), and due to some infrastructure complexities on our end, would prefer to have this config hosted by you if that's agreeable.

Please let me know if there are any questions about any of this.

Thanks!