### PR TITLE
Update SMTP settings for Microsoft Outlook accounts

### DIFF
--- a/ispdb/hotmail.com.xml
+++ b/ispdb/hotmail.com.xml
@@ -129,7 +129,7 @@
       </pop3>
     </incomingServer>
     <outgoingServer type="smtp">
-      <hostname>smtp.office365.com</hostname>
+      <hostname>smtp-mail.outlook.com</hostname>
       <port>587</port>
       <socketType>STARTTLS</socketType>
       <authentication>OAuth2</authentication>


### PR DESCRIPTION
As per https://support.microsoft.com/en-us/office/pop-imap-and-smtp-settings-for-outlook-com-d088b986-291d-42b8-9564-9c414e2aa040, Microsoft recommends using smtp-mail.outlook.com as an Outlook SMTP server.