### PR TITLE
Add settings for free rediffmail accounts

### DIFF
--- a/ispdb/rediffmail.com.xml
+++ b/ispdb/rediffmail.com.xml
@@ -7,25 +7,18 @@
     <displayShortName>Rediff</displayShortName>
     <incomingServer type="pop3">
       <hostname>pop.rediffmail.com</hostname>
-      <port>110</port>
-      <socketType>plain</socketType>
-      <authentication>password-cleartext</authentication>
-      <username>%EMAILADDRESS%</username>
-    </incomingServer>
-    <incomingServer type="pop3">
-      <hostname>pop.rediffmail.com</hostname>
       <port>995</port>
       <socketType>SSL</socketType>
       <authentication>password-cleartext</authentication>
       <username>%EMAILADDRESS%</username>
     </incomingServer>
-    <outgoingServer type="smtp">
-      <hostname>smtp.rediffmail.com</hostname>
-      <port>587</port>
+    <incomingServer type="pop3">
+      <hostname>pop.rediffmail.com</hostname>
+      <port>110</port>
       <socketType>plain</socketType>
       <authentication>password-cleartext</authentication>
       <username>%EMAILADDRESS%</username>
-    </outgoingServer>
+    </incomingServer>
     <outgoingServer type="smtp">
       <hostname>smtp.rediffmail.com</hostname>
       <port>586</port>
@@ -37,6 +30,13 @@
       <hostname>smtp.rediffmail.com</hostname>
       <port>465</port>
       <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </outgoingServer>
+    <outgoingServer type="smtp">
+      <hostname>smtp.rediffmail.com</hostname>
+      <port>587</port>
+      <socketType>plain</socketType>
       <authentication>password-cleartext</authentication>
       <username>%EMAILADDRESS%</username>
     </outgoingServer>

--- a/ispdb/rediffmail.com.xml
+++ b/ispdb/rediffmail.com.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<clientConfig version="1.1">
+  <emailProvider id="rediffmail.com">
+    <domain>rediffmail.com</domain>
+    <displayName>Rediffmail</displayName>
+    <displayShortName>Rediff</displayShortName>
+    <incomingServer type="pop3">
+      <hostname>pop.rediffmail.com</hostname>
+      <port>110</port>
+      <socketType>plain</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+    <incomingServer type="pop3">
+      <hostname>pop.rediffmail.com</hostname>
+      <port>995</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+    <outgoingServer type="smtp">
+      <hostname>smtp.rediffmail.com</hostname>
+      <port>587</port>
+      <socketType>plain</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </outgoingServer>
+    <outgoingServer type="smtp">
+      <hostname>smtp.rediffmail.com</hostname>
+      <port>586</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </outgoingServer>
+    <outgoingServer type="smtp">
+      <hostname>smtp.rediffmail.com</hostname>
+      <port>465</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </outgoingServer>
+  </emailProvider>
+</clientConfig>


### PR DESCRIPTION
Rediffmail is a famous free email provider in India. Add SMTP and POP3 settings for the same. It does not support IMAP in its free plan.