### PR TITLE
Add verizon IMAP configuration and reflect that's it's now AOL.

### DIFF
--- a/ispdb/verizon.net.xml
+++ b/ispdb/verizon.net.xml
@@ -3,19 +3,32 @@
     <domain>verizon.net</domain>
     <displayName>Verizon Online</displayName>
     <displayShortName>Verizon</displayShortName>
+    <incomingServer type="imap">
+      <hostname>imap.aol.com</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>OAuth2</authentication>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
     <incomingServer type="pop3">
-      <hostname>pop.verizon.net</hostname>
+      <hostname>pop.aol.com</hostname>
       <port>995</port>
       <socketType>SSL</socketType>
-      <username>%EMAILLOCALPART%</username>
+      <username>%EMAILADDRESS%</username>
+      <authentication>OAuth2</authentication>
       <authentication>password-cleartext</authentication>
     </incomingServer>
     <outgoingServer type="smtp">
-      <hostname>smtp.verizon.net</hostname>
+      <hostname>smtp.aol.com</hostname>
       <port>465</port>
       <socketType>SSL</socketType>
-      <username>%EMAILLOCALPART%</username>
+      <username>%EMAILADDRESS%</username>
+      <authentication>OAuth2</authentication>
       <authentication>password-cleartext</authentication>
     </outgoingServer>
+    <documentation url="https://help.aol.com/articles/how-do-i-set-up-other-email-applications-to-send-and-receive-my-verizon-net-mail">
+       <descr lang="en">Configure POP and IMAP settings for Verizon.net AOL Mail accounts</descr>
+    </documentation>
   </emailProvider>
 </clientConfig>


### PR DESCRIPTION
Using the AOL names directly (they are the same servers) so OAuth2 will work.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1978413
See https://www.verizon.com/support/residential/announcements/email-policy-announcement