### PR TITLE
Add STARTTLS encryption settings for Gmail SMTP server

### DIFF
--- a/ispdb/googlemail.com.xml
+++ b/ispdb/googlemail.com.xml
@@ -32,6 +32,14 @@
     </incomingServer>
     <outgoingServer type="smtp">
       <hostname>smtp.gmail.com</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>OAuth2</authentication>
+      <authentication>password-cleartext</authentication>
+    </outgoingServer>
+    <outgoingServer type="smtp">
+      <hostname>smtp.gmail.com</hostname>
       <port>465</port>
       <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>


### PR DESCRIPTION
As per https://developers.google.com/workspace/gmail/imap/imap-smtp#protocol , Gmail's SMTP server also supports STARTTLS on port 587