### PR TITLE
Add STARTTLS encryption settings for Yahoo SMTP server

### DIFF
--- a/ispdb/yahoo.com.xml
+++ b/ispdb/yahoo.com.xml
@@ -53,6 +53,14 @@
     </incomingServer>
     <outgoingServer type="smtp">
       <hostname>smtp.mail.yahoo.com</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>OAuth2</authentication>
+      <authentication>password-cleartext</authentication>
+    </outgoingServer>
+    <outgoingServer type="smtp">
+      <hostname>smtp.mail.yahoo.com</hostname>
       <port>465</port>
       <socketType>SSL</socketType>
       <username>%EMAILADDRESS%</username>


### PR DESCRIPTION
https://help.yahoo.com/kb/pop-access-settings-instructions-yahoo-mail-sln4724.html says Yahoo's SMTP server supports port 465 and 587 with SSL and TLS. While it's not clear what port is for which encryption, upon trial and error, 465 is for SSL and 587 is for TLS.