### PR TITLE
Add STARTTLS encryption settings for AOL SMTP server

### DIFF
--- a/ispdb/aol.com.xml
+++ b/ispdb/aol.com.xml
@@ -45,6 +45,14 @@
     </incomingServer>
     <outgoingServer type="smtp">
       <hostname>smtp.aol.com</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+      <authentication>OAuth2</authentication>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </outgoingServer>
+    <outgoingServer type="smtp">
+      <hostname>smtp.aol.com</hostname>
       <port>465</port>
       <socketType>SSL</socketType>
       <authentication>OAuth2</authentication>


### PR DESCRIPTION
I couldn't find any documentation for AOL's SMTP server, but upon trial and error, just like Yahoo, AOL also supports STARTTLS at 587 and SSL at 465.